### PR TITLE
Default values for `stb` and `ack` output registers

### DIFF
--- a/adder/adder.v
+++ b/adder/adder.v
@@ -30,12 +30,12 @@ module adder(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [31:0] s_output_z;
-  reg       s_input_a_ack;
-  reg       s_input_b_ack;
+  reg       s_input_a_ack = 0;
+  reg       s_input_b_ack = 0;
 
-  reg       [3:0] state;
+  reg       [3:0] state = get_a;
   parameter get_a         = 4'd0,
             get_b         = 4'd1,
             unpack        = 4'd2,
@@ -95,7 +95,7 @@ module adder(
 
       special_cases:
       begin
-        //if a is NaN or b is NaN return NaN 
+        //if a is NaN or b is NaN return NaN
         if ((a_e == 128 && a_m != 0) || (b_e == 128 && b_m != 0)) begin
           z[31] <= 1;
           z[30:23] <= 255;
@@ -279,4 +279,3 @@ module adder(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/divider/divider.v
+++ b/divider/divider.v
@@ -30,12 +30,12 @@ module divider(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [31:0] s_output_z;
-  reg       s_input_a_ack;
-  reg       s_input_b_ack;
+  reg       s_input_a_ack = 0;
+  reg       s_input_b_ack = 0;
 
-  reg       [3:0] state;
+  reg       [3:0] state = get_a;
   parameter get_a         = 4'd0,
             get_b         = 4'd1,
             unpack        = 4'd2,
@@ -98,14 +98,14 @@ module divider(
 
       special_cases:
       begin
-        //if a is NaN or b is NaN return NaN 
+        //if a is NaN or b is NaN return NaN
         if ((a_e == 128 && a_m != 0) || (b_e == 128 && b_m != 0)) begin
           z[31] <= 1;
           z[30:23] <= 255;
           z[22] <= 1;
           z[21:0] <= 0;
           state <= put_z;
-          //if a is inf and b is inf return NaN 
+          //if a is inf and b is inf return NaN
         end else if ((a_e == 128) && (b_e == 128)) begin
           z[31] <= 1;
           z[30:23] <= 255;
@@ -313,4 +313,3 @@ module divider(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/double_adder/double_adder.v
+++ b/double_adder/double_adder.v
@@ -30,12 +30,12 @@ module double_adder(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [63:0] s_output_z;
-  reg       s_input_a_ack;
-  reg       s_input_b_ack;
+  reg       s_input_a_ack = 0;
+  reg       s_input_b_ack = 0;
 
-  reg       [3:0] state;
+  reg       [3:0] state = get_a;
   parameter get_a         = 4'd0,
             get_b         = 4'd1,
             unpack        = 4'd2,
@@ -95,7 +95,7 @@ module double_adder(
 
       special_cases:
       begin
-        //if a is NaN or b is NaN return NaN 
+        //if a is NaN or b is NaN return NaN
         if ((a_e == 1024 && a_m != 0) || (b_e == 1024 && b_m != 0)) begin
           z[63] <= 1;
           z[62:52] <= 2047;
@@ -279,4 +279,3 @@ module double_adder(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/double_divider/double_divider.v
+++ b/double_divider/double_divider.v
@@ -30,12 +30,12 @@ module double_divider(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [63:0] s_output_z;
-  reg       s_input_a_ack;
-  reg       s_input_b_ack;
+  reg       s_input_a_ack = 0;
+  reg       s_input_b_ack = 0;
 
-  reg       [3:0] state;
+  reg       [3:0] state = get_a;
   parameter get_a         = 4'd0,
             get_b         = 4'd1,
             unpack        = 4'd2,
@@ -98,14 +98,14 @@ module double_divider(
 
       special_cases:
       begin
-        //if a is NaN or b is NaN return NaN 
+        //if a is NaN or b is NaN return NaN
         if ((a_e == 1024 && a_m != 0) || (b_e == 1024 && b_m != 0)) begin
           z[63] <= 1;
           z[62:52] <= 2047;
           z[51] <= 1;
           z[50:0] <= 0;
           state <= put_z;
-          //if a is inf and b is inf return NaN 
+          //if a is inf and b is inf return NaN
         end else if ((a_e == 1024) && (b_e == 1024)) begin
           z[63] <= 1;
           z[62:52] <= 2047;
@@ -313,4 +313,3 @@ module double_divider(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/double_multiplier/double_multiplier.v
+++ b/double_multiplier/double_multiplier.v
@@ -29,12 +29,12 @@ module double_multiplier(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [63:0] s_output_z;
-  reg       s_input_a_ack;
-  reg       s_input_b_ack;
+  reg       s_input_a_ack = 0;
+  reg       s_input_b_ack = 0;
 
-  reg       [3:0] state;
+  reg       [3:0] state = get_a;
   parameter get_a         = 4'd0,
             get_b         = 4'd1,
             unpack        = 4'd2,
@@ -94,7 +94,7 @@ module double_multiplier(
 
       special_cases:
       begin
-        //if a is NaN or b is NaN return NaN 
+        //if a is NaN or b is NaN return NaN
         if ((a_e == 1024 && a_m != 0) || (b_e == 1024 && b_m != 0)) begin
           z[63] <= 1;
           z[62:52] <= 2047;
@@ -267,4 +267,3 @@ module double_multiplier(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/double_to_float/double_to_float.v
+++ b/double_to_float/double_to_float.v
@@ -22,11 +22,11 @@ module double_to_float(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [31:0] s_output_z;
-  reg       s_input_a_ack;
+  reg       s_input_a_ack = 0;
 
-  reg       [1:0] state;
+  reg       [1:0] state = get_a;
   parameter get_a         = 3'd0,
             unpack        = 3'd1,
             denormalise   = 3'd2,
@@ -130,4 +130,3 @@ module double_to_float(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/double_to_long/double_to_long.v
+++ b/double_to_long/double_to_long.v
@@ -22,11 +22,11 @@ module double_to_long(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [63:0] s_output_z;
-  reg       s_input_a_ack;
+  reg       s_input_a_ack = 0;
 
-  reg       [2:0] state;
+  reg       [2:0] state = get_a;
   parameter get_a         = 3'd0,
             special_cases = 3'd1,
             unpack        = 3'd2,
@@ -123,4 +123,3 @@ module double_to_long(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/float_to_double/float_to_double.v
+++ b/float_to_double/float_to_double.v
@@ -22,12 +22,12 @@ module float_to_double(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [63:0] s_output_z;
-  reg       s_input_a_ack;
+  reg       s_input_a_ack = 0;
   reg       s_input_b_ack;
 
-  reg       [1:0] state;
+  reg       [1:0] state = get_a;
   parameter get_a         = 3'd0,
             convert_0     = 3'd1,
             normalise_0   = 3'd2,
@@ -108,4 +108,3 @@ module float_to_double(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/float_to_int/float_to_int.v
+++ b/float_to_int/float_to_int.v
@@ -22,11 +22,11 @@ module float_to_int(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [31:0] s_output_z;
-  reg       s_input_a_ack;
+  reg       s_input_a_ack = 0;
 
-  reg       [2:0] state;
+  reg       [2:0] state = get_a;
   parameter get_a         = 3'd0,
             special_cases = 3'd1,
             unpack        = 3'd2,
@@ -113,4 +113,3 @@ module float_to_int(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/int_to_float/int_to_float.v
+++ b/int_to_float/int_to_float.v
@@ -22,12 +22,12 @@ module int_to_float(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [31:0] s_output_z;
-  reg       s_input_a_ack;
+  reg       s_input_a_ack = 0;
   reg       s_input_b_ack;
 
-  reg       [2:0] state;
+  reg       [2:0] state = get_a;
   parameter get_a         = 3'd0,
             convert_0     = 3'd1,
             convert_1     = 3'd2,
@@ -138,4 +138,3 @@ module int_to_float(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/long_to_double/long_to_double.v
+++ b/long_to_double/long_to_double.v
@@ -22,12 +22,12 @@ module long_to_double(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [63:0] s_output_z;
-  reg       s_input_a_ack;
+  reg       s_input_a_ack = 0;
   reg       s_input_b_ack;
 
-  reg       [2:0] state;
+  reg       [2:0] state = get_a;
   parameter get_a         = 3'd0,
             convert_0     = 3'd1,
             convert_1     = 3'd2,
@@ -138,4 +138,3 @@ module long_to_double(
   assign output_z = s_output_z;
 
 endmodule
-

--- a/multiplier/multiplier.v
+++ b/multiplier/multiplier.v
@@ -29,12 +29,12 @@ module multiplier(
   output    output_z_stb;
   input     output_z_ack;
 
-  reg       s_output_z_stb;
+  reg       s_output_z_stb = 0;
   reg       [31:0] s_output_z;
-  reg       s_input_a_ack;
-  reg       s_input_b_ack;
+  reg       s_input_a_ack = 0;
+  reg       s_input_b_ack = 0;
 
-  reg       [3:0] state;
+  reg       [3:0] state = get_a;
   parameter get_a         = 4'd0,
             get_b         = 4'd1,
             unpack        = 4'd2,
@@ -94,7 +94,7 @@ module multiplier(
 
       special_cases:
       begin
-        //if a is NaN or b is NaN return NaN 
+        //if a is NaN or b is NaN return NaN
         if ((a_e == 128 && a_m != 0) || (b_e == 128 && b_m != 0)) begin
           z[31] <= 1;
           z[30:23] <= 255;
@@ -267,4 +267,3 @@ module multiplier(
   assign output_z = s_output_z;
 
 endmodule
-


### PR DESCRIPTION
This allow to don't need to reset the components at boot to have them initialized.